### PR TITLE
use keycloak.host as a property (EAP startup parameter) RHMAP-974

### DIFF
--- a/servers/ups-as7/src/main/webapp/WEB-INF/keycloak.json
+++ b/servers/ups-as7/src/main/webapp/WEB-INF/keycloak.json
@@ -1,6 +1,6 @@
 {
   "realm" : "aerogear",
-  "auth-server-url" : "/auth",
+  "auth-server-url" : "${keycloak.host}/auth",
   "ssl-required" : "none",
   "resource" : "unified-push-server",
   "bearer-only" : true,


### PR DESCRIPTION
* this allows use to configure the host using `-Dkeycloak.host=...` property.

e.g.: `./bin/standalone.sh -Dkeycloak.host=http://localhost:9081`

https://issues.jboss.org/browse/RHMAP-974