### PR TITLE
Added a requestId filter to assign the request ID

### DIFF
--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/util/RequestIdFilter.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/util/RequestIdFilter.java
@@ -1,0 +1,79 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright Red Hat, Inc., and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.aerogear.unifiedpush.rest.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+import java.io.IOException;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.annotation.WebFilter;
+import javax.servlet.http.HttpServletRequest;
+import java.util.UUID;
+
+/**
+ * This filter will check for a request ID header in the request. The requestID will be applied to the logger thread context for output in any log statements.
+ */
+@WebFilter(urlPatterns = "*")
+public class RequestIdFilter implements Filter {
+
+  private final Logger logger = LoggerFactory.getLogger(RequestIdFilter.class);
+  public static final String FH_REQUEST_ID = "X-FH-REQUEST-ID";
+
+  public RequestIdFilter() {
+  }
+
+  @Override
+  public void init(FilterConfig filterConfig) throws ServletException {
+  }
+
+  public static String getRequestId(final HttpServletRequest request) {
+    final String requestId = request.getHeader(FH_REQUEST_ID);
+    if (requestId != null) {
+      return  requestId;
+    }
+    return UUID.randomUUID().toString();
+  }
+
+  @Override
+  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+
+    HttpServletRequest httpRequest = (HttpServletRequest) request;
+    final String reqId = getRequestId(httpRequest);
+
+    try {
+      MDC.clear();
+      //Adding the request ID to Thread Storage
+      MDC.put("reqId", reqId);
+
+      logger.debug("Got Request ID " + reqId);
+
+      chain.doFilter(request, response);
+    } finally {
+      MDC.clear();
+    }
+  }
+
+  public void destroy() {
+  }
+}

--- a/jaxrs/src/test/java/org/jboss/aerogear/unifiedpush/rest/util/RequestIdFilterTest.java
+++ b/jaxrs/src/test/java/org/jboss/aerogear/unifiedpush/rest/util/RequestIdFilterTest.java
@@ -1,0 +1,53 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright Red Hat, Inc., and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.aerogear.unifiedpush.rest.util;
+
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import javax.servlet.FilterChain;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import static org.mockito.Mockito.verify;
+
+public class RequestIdFilterTest {
+
+  public static final String FH_REQUEST_ID = "X-FH-REQUEST-ID";
+
+  @Mock
+  HttpServletRequest request;
+  @Mock
+  HttpServletResponse response;
+  @Mock
+  FilterChain chain;
+
+  @Test
+  public void requestIdHeaderAssigned() throws Exception {
+    MockitoAnnotations.initMocks(this);
+
+    RequestIdFilter filter = new RequestIdFilter();
+
+    String mockString = "51f7b609-a852-4744-b07e-66b43af343e3";
+    Mockito.when(request.getHeader(FH_REQUEST_ID)).thenReturn(mockString);
+    filter.doFilter(request, response, chain);
+
+    verify(chain).doFilter(request, response);
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -123,14 +123,8 @@
 
             <dependency>
                 <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-api</artifactId>
-                <version>${slfj4.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-simple</artifactId>
-                <version>${slfj4.version}</version>
+                <artifactId>slf4j-log4j12</artifactId>
+                <version>1.7.21</version>
             </dependency>
 
         </dependencies>


### PR DESCRIPTION
# Motivation

Output logs do not contain the ID of the request sent from other RHMAP components. Adding this request ID to logging statements would allow easier searching for logs related to requests from the platform.
# Changes

Added a filter to find the `X-FH-REQUEST-ID` header in a request and assign it to the logging thread context.