### PR TITLE
[RHMAP-7856] Add module.xml files for the JSON-logging jars for EAP

### DIFF
--- a/logging/src/main/resources/modules/javax/json/api/main/module.xml
+++ b/logging/src/main/resources/modules/javax/json/api/main/module.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" ?>
+<!--
+  JBoss, Home of Professional Open Source
+  Copyright Red Hat, Inc., and individual contributors
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<module xmlns="urn:jboss:module:1.1" name="javax.json.api">
+    <resources>
+        <resource-root path="javax.json.jar"/>
+    </resources>
+</module>
+

--- a/logging/src/main/resources/modules/org/jboss/logmanager/ext/main/module.xml
+++ b/logging/src/main/resources/modules/org/jboss/logmanager/ext/main/module.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" ?>
+<!--
+  JBoss, Home of Professional Open Source
+  Copyright Red Hat, Inc., and individual contributors
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<module xmlns="urn:jboss:module:1.1" name="org.jboss.logmanager.ext">
+
+    <resources>
+        <resource-root path="jboss-logmanager-ext.jar"/>
+    </resources>
+
+    <dependencies>
+        <module name="org.jboss.logmanager"/>
+        <module name="javax.json.api"/>
+        <module name="javax.xml.stream.api"/>
+    </dependencies>
+</module>
+


### PR DESCRIPTION
# Motivation

Add module.xml files for download via fhcap in order to install EAP modules required for JSON-formatted logging.

This kind of setup is the same for the [database drivers](https://github.com/fheng/aerogear-unifiedpush-server/tree/rhmap/databases/src/main/resources/modules)

Related fhcap PR up in a bit.

# Changes
- Add module.xml for logmanager-ext
- add module.xml for javax.json.api

ping @matzew @nialldonnellyfh 