### PR TITLE
Update bower

### DIFF
--- a/admin-ui/.bowerrc
+++ b/admin-ui/.bowerrc
@@ -4,5 +4,6 @@
     "packages": ".build-tmp/bower-cache",
     "registry": ".build-tmp/bower-registry"
   },
-  "tmp": ".build-tmp/bower-tmp"
+  "tmp": ".build-tmp/bower-tmp",
+  "registry": "https://registry.bower.io"
 }


### PR DESCRIPTION
Bower recently migrated their registry away from Heroku without bumping their major version. Version 1.8.4 uses the new registry while older versions no longer work.